### PR TITLE
Don't run PDF generation for non-main branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,16 @@
 name: GitHub CI
 
-on: [push]
+on:
+  push:
+    branches:
+    - main
 
 permissions:
   contents: write
 
 jobs:
-  minimal:
+  autogen:
+    name: build PDFs etc
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -25,6 +29,5 @@ jobs:
       run: |
         make TEXINPUTS=./lib//:
     - uses: stefanzweifel/git-auto-commit-action@v4
-      if: github.ref_name == 'main'
       with:
         commit_message: Automatic generation of PDF and previews


### PR DESCRIPTION
This avoids running the PDF generation process for all commits to branches other than _main_.
This means that a error in a pull request will not be detected until after it has been merged.

I also picked a more meaningful name.